### PR TITLE
Allow to set COIN_RPC_PORT from env using default 7000.

### DIFF
--- a/Dockerfile.blockchain
+++ b/Dockerfile.blockchain
@@ -28,4 +28,4 @@ COPY komodod /data/
 COPY start_things.sh /data/
 COPY bin/init /data/
 
-CMD ./start_things.sh >> log.log
+CMD ./start_things.sh

--- a/start_blockchain.py
+++ b/start_blockchain.py
@@ -12,12 +12,17 @@ from slickrpc import Proxy
 #test_pubkey = '021607076d7a2cb148d542fb9644c04ffc22d2cca752f80755a0402a24c567b17a'
 
 clients_to_start = int(os.environ['CLIENTS'])
+rpc_port = 7000
+if 'COIN_RPC_PORT' in os.environ:
+    rpc_port = int(os.environ['COIN_RPC_PORT'])
 ac_name = os.environ['CHAIN']
 test_address = os.environ['TEST_ADDY']
 test_wif = os.environ['TEST_WIF']
 test_pubkey = os.environ['TEST_PUBKEY']
 # expecting REGTEST or REGULAR there
-chain_start_mode = os.environ['CHAIN_MODE']
+chain_start_mode = 'REGTEST'
+if 'CHAIN_MODE' in os.environ:
+    chain_start_mode = os.environ['CHAIN_MODE']
 
 # pre-creating separate folders and configs
 for i in range(clients_to_start):
@@ -26,17 +31,19 @@ for i in range(clients_to_start):
     with open("/data/node_" + str(i) + "/" + ac_name + ".conf", 'a') as conf:
         conf.write("rpcuser=test" + '\n')
         conf.write("rpcpassword=test" + '\n')
-        conf.write("rpcport=" + str(7000 + i) + '\n')
+        conf.write("rpcport=" + str(rpc_port + i) + '\n')
         conf.write("rpcbind=0.0.0.0\n")
         conf.write("rpcallowip=0.0.0.0/0\n")
+
+print('config is ready')
 
 #start numnodes daemons, changing folder name and port
 for i in range(clients_to_start):
     # all nodes should search for first "mother" node
     if i == 0:
         start_args = ['./komodod', '-ac_name='+ac_name, '-conf=' + sys.path[0] + '/node_' + str(i) + "/" + ac_name + ".conf",
-                         '-rpcport=' + str(7000 + i), '-port=' + str(6000 + i), '-datadir=' + sys.path[0] + '/node_' + str(i),
-                         '-ac_supply=10000000000', '-ac_cc=2', '-whitelist=127.0.0.1']
+                         '-rpcport=' + str(rpc_port + i), '-port=' + str(6000 + i), '-datadir=' + sys.path[0] + '/node_' + str(i),
+                         '-ac_supply=10000000000', '-ac_cc=2', '-ac_sapling=1', '-whitelist=127.0.0.1']
         if chain_start_mode == 'REGTEST':
             start_args.append('-regtest')
             start_args.append('-daemon')
@@ -46,8 +53,8 @@ for i in range(clients_to_start):
         time.sleep(5)
     else:
         start_args = ['./komodod', '-ac_name='+ac_name, '-conf=' + sys.path[0] + '/node_' + str(i) + "/" + ac_name + ".conf",
-                         '-rpcport=' + str(7000 + i), '-port=' + str(6000 + i), '-datadir=' + sys.path[0] + '/node_' + str(i),
-                         '-ac_supply=10000000000', '-ac_cc=2', '-addnode=127.0.0.1:6000', '-whitelist=127.0.0.1', '-listen=0', '-pubkey='+test_pubkey]
+                         '-rpcport=' + str(rpc_port + i), '-port=' + str(6000 + i), '-datadir=' + sys.path[0] + '/node_' + str(i),
+                         '-ac_supply=10000000000', '-ac_cc=2', '-ac_sapling=1', '-addnode=127.0.0.1:6000', '-whitelist=127.0.0.1', '-listen=0', '-pubkey='+test_pubkey]
         if chain_start_mode == 'REGTEST':
             start_args.append('-regtest')
             start_args.append('-daemon')
@@ -59,7 +66,7 @@ for i in range(clients_to_start):
 
 #creating rpc proxies for all nodes
 for i in range(clients_to_start):
-    rpcport = 7000 + i
+    rpcport = rpc_port + i
     globals()['proxy_%s' % i] = Proxy("http://%s:%s@127.0.0.1:%d"%("test", "test", int(rpcport)))
 time.sleep(2)
 
@@ -82,10 +89,10 @@ if chain_start_mode == 'REGTEST':
     while True:
        if int(os.environ['CLIENTS']) > 1:
            proxy_1.generate(1)
-           time.sleep(5)
+           time.sleep(2)
        else:
            proxy_0.generate(1)
-           time.sleep(5)
+           time.sleep(2)
 else:
     if int(os.environ['CLIENTS']) > 1:
         print("Starting mining on node 2")


### PR DESCRIPTION
Set the default CHAIN_MODE to REGTEST.
Add logging statement when config file is generated.
Activate sapling from 1st block.
Stop redirecting the start_things output to file since MM2 tests
track the container stdout and wait for config to be ready.